### PR TITLE
Add stripe

### DIFF
--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -1,6 +1,6 @@
 param(
     # overwrite upstream param
-    [String]$upstream = "<username>/<bucketname>:main"
+    [String]$upstream = "TheBloxMarket/scoop-stripe:main"
 )
 
 if (!$env:SCOOP_HOME) { $env:SCOOP_HOME = Convert-Path (scoop prefix scoop) }

--- a/bucket/stripe.json
+++ b/bucket/stripe.json
@@ -1,0 +1,32 @@
+{
+    "version": "1.27.00",
+    "description": "Stripe's CLI Tool",
+    "homepage": "https://github.com/stripe/stripe-cli",
+    "license": "Apache-2.0",
+    "notes": "This is an unofficial bucket, used to make managing the tool easier",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/stripe/stripe-cli/releases/download/v1.27.0/stripe_1.27.0_windows_x86_64.zip",
+            "hash": "3020eed1cbe6981110dba5509d7e0189f7013e5f3b518fdb8e080e610e6a6f81"
+        },
+        "32bit": {
+            "url": "https://github.com/stripe/stripe-cli/releases/download/v1.27.0/stripe_1.27.0_windows_i386.zip",
+            "hash": "043283fad45ab8a7058673033c7e8d8cddc8c0edb0e63e9d076af60f42fcfac6"
+        }
+    },
+    "bin": "stripe.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/stripe/stripe-cli/releases/download/v$version/stripe_$version_windows_x86_64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/stripe/stripe-cli/releases/download/v$version/stripe_$version_windows_i386.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/stripe-windows-checksums.txt"
+        }
+    }
+}

--- a/bucket/stripe.json
+++ b/bucket/stripe.json
@@ -15,7 +15,9 @@
         }
     },
     "bin": "stripe.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/stripe/stripe-cli"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
This PR adds Stripe to the bucket, allowing for scoop to manage the install of the [Stripe CLI tool](https://docs.stripe.com/stripe-cli?install-method=windows).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
